### PR TITLE
Revert "Modified IP address configuration so RemoteSyslogAppender sen…

### DIFF
--- a/include/log4cpp/RemoteSyslogAppender.hh
+++ b/include/log4cpp/RemoteSyslogAppender.hh
@@ -130,7 +130,7 @@ namespace log4cpp {
 #else	
 		int		_socket;
 #endif
-        struct in_addr* _ipAddr;
+        in_addr_t _ipAddr;
         private:
         int _cludge;
     };

--- a/src/RemoteSyslogAppender.cpp
+++ b/src/RemoteSyslogAppender.cpp
@@ -111,7 +111,7 @@ namespace log4cpp {
                     return; // fail silently                    
                 }
             }
-            _ipAddr = *(pent->h_addr);
+            _ipAddr = *(in_addr_t*)(pent->h_addr); // fixed bug #1579890
         }
         // Get a datagram socket.
         

--- a/src/RemoteSyslogAppender.cpp
+++ b/src/RemoteSyslogAppender.cpp
@@ -111,7 +111,7 @@ namespace log4cpp {
                     return; // fail silently                    
                 }
             }
-            _ipAddr = (struct in_addr*)pent->h_addr;
+            _ipAddr = *(pent->h_addr);
         }
         // Get a datagram socket.
         
@@ -143,14 +143,8 @@ namespace log4cpp {
         sockaddr_in sain;
         sain.sin_family = AF_INET;
         sain.sin_port   = htons (_portNumber);
-
-        if (_ipAddr == NULL)
-        {
-            return;    // Fail silently
-        }
-        
         // NO, do NOT use htonl on _ipAddr. Is already in network order.
-        sain.sin_addr.s_addr = _ipAddr->s_addr;
+        sain.sin_addr.s_addr = _ipAddr;
 
         while (messageLength > 0) {
             /* if packet larger than maximum (900 bytes), split


### PR DESCRIPTION
…ds directly to the given IP address instead of broadcasting."

Commit 22f544f818cb9464de5a7b826dd3ec2e5ca6b3d4 is invalid because it saves the IP address returned by `gethostbyname()`/`gethostbyaddr()` as a pointer to an internal data structure of the sockets library. The manual says that

> The gethostbyaddr() and gethostbyname() functions may return pointers to static data, which may be overwritten by subsequent calls to any of these functions.
(source: http://pubs.opengroup.org/onlinepubs/009695399/functions/gethostbyaddr.html)

Beside this issue, I do not see how this patch implements what is claimed in the commit message.