### PR TITLE
Renamed library and pkg-config file to orocos-log4cpp and set version to 2.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,11 +30,7 @@ ELSE (WIN32)
   ENDIF (APPLE)
 ENDIF (WIN32)
 
-#IF ( CMAKE_BUILD_TYPE MATCHES "Debug" )
-#  SET ( LOG4CPP_LIBRARY_NAME "log4cppD" )
-#ELSE ( CMAKE_BUILD_TYPE MATCHES "Debug" )
-  SET ( LOG4CPP_LIBRARY_NAME "log4cpp" )
-#ENDIF ( CMAKE_BUILD_TYPE MATCHES "Debug" )
+SET ( LOG4CPP_LIBRARY_NAME "orocos-log4cpp" )
 
 ADD_LIBRARY ( ${LOG4CPP_LIBRARY_NAME} SHARED
   src/Appender.cpp
@@ -91,10 +87,8 @@ IF (WIN32)
 #  SET_TARGET_PROPERTIES(${LOG4CPP_LIBRARY_NAME} PROPERTIES LINK_FLAGS /NODEFAULTLIB:msvcrt)
 ENDIF (WIN32)
 
-# Note: this so-version is required by OCL, such that it can distinguish 'regular' log4cpp
-# from 'rtt' log4cpp.
-SET(VERSION "6.0.0")
-SET(SOVERSION "6.0")
+SET(VERSION "2.9.0")
+SET(SOVERSION "2.9")
 SET_TARGET_PROPERTIES(${LOG4CPP_LIBRARY_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${SOVERSION})
 
 ADD_DEFINITIONS(${LOG4CPP_CFLAGS})
@@ -119,18 +113,18 @@ SET(prefix "${CMAKE_INSTALL_PREFIX}")
 SET(exec_prefix "\${prefix}")
 SET(log4cpp_cflags "")
 SET(log4cpp_libs "${LOG4CPP_LIBS}")
-SET(includedir "\${prefix}/include")
+SET(includedir "\${prefix}/include/orocos")
 SET(libdir "\${prefix}/lib")
-CONFIGURE_FILE(log4cpp.pc.in ${CMAKE_CURRENT_BINARY_DIR}/log4cpp.pc @ONLY)
+CONFIGURE_FILE(log4cpp.pc.in ${CMAKE_CURRENT_BINARY_DIR}/orocos-log4cpp.pc @ONLY)
 
 INSTALL(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/log4cpp.pc
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/orocos-log4cpp.pc
   DESTINATION lib/pkgconfig
   )
 
 INSTALL (
   DIRECTORY include/log4cpp
-  DESTINATION include
+  DESTINATION include/orocos
   PATTERN "config.h.in" EXCLUDE
   PATTERN ".svn" EXCLUDE
   PATTERN "*.am" EXCLUDE
@@ -140,7 +134,7 @@ INSTALL (
 
 INSTALL (
   FILES ${CMAKE_CURRENT_BINARY_DIR}/include/log4cpp/config.h
-  DESTINATION include/log4cpp
+  DESTINATION include/orocos/log4cpp
   )
 
 INSTALL(TARGETS ${LOG4CPP_LIBRARY_NAME}

--- a/log4cpp.pc.in
+++ b/log4cpp.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: @PACKAGE@
 Description: C++ library for flexible logging, modeled after Log4j
 Version: @VERSION@
-Libs: -L${libdir} -llog4cpp
+Libs: -L${libdir} -l@LOG4CPP_LIBRARY_NAME@
 Cflags: -I${includedir} @log4cpp_cflags@
 Libs.private: @log4cpp_libs@


### PR DESCRIPTION
This patch would allow to install the patched version of log4cpp alongside the [original log4cpp](https://packages.debian.org/source/log4cpp) package without potential conflicts and without the need to increase the version number to 6.0.0 as a criteria to detect the patched log4cpp library in ocl.

rtt and ocl need a minimal patch to change the library name and to remove the version 6.0.0 check.