### PR TITLE
Support OS X 10.11 with system integrity protection enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,12 @@ SET(VERSION "2.9.0")
 SET(SOVERSION "2.9")
 SET_TARGET_PROPERTIES(${LOG4CPP_LIBRARY_NAME} PROPERTIES VERSION ${VERSION} SOVERSION ${SOVERSION})
 
+# Ensure that the full path+lib name is used in dynamic library dependencies
+# in dependent libraries/executables. Without this, CMake drops the path and
+# the dependency becomes just the lib name (which requires working DYLD_xxx)
+SET_TARGET_PROPERTIES(${LOG4CPP_LIBRARY_NAME} PROPERTIES
+    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
 ADD_DEFINITIONS(${LOG4CPP_CFLAGS})
 
 ###########################################################


### PR DESCRIPTION
Downstream linking with this library is broken on OS X 10.11 with system integrity protection (SIP) enabled (which is the default). The OCL deployer will not launch in OS X 10.11, due to linking settings in the library generated from here.

cmake: Add INSTALL_NAME_DIR to library to fix OS X 10.11 dynamic path issues

OS X 10.11 with System Integrity Protection (SIP) [1] turned on (which is
the default), purges all DYLD_xxx env. var's before executing a program.
This means that dynamic libraries can not be found via DYLD_xxx paths, and
so all dynamic library dependencies must have a full path specified.

Without this property set, dependent libraries/executables that dynamically
link with log4cpp end up without the path information, and thus fail to
load in 10.11 w/ SIP enabled. Even if CMake provides a full path to the
log4cpp library, the output dependent dynamic library has a log4cpp
entry like

liblog4cpp.6.0.dylib (compatibility version 6.0.0, current version 6.0.0)

but with this property set in log4cpp (and no changes in the dependent
package), then the resulting log4cpp entry in the dependent library is

/opt/orocos/lib/liblog4cpp.6.0.dylib (compatibility version 6.0.0, current version 6.0.0)

Not entirely sure why this entry fixes the problem, but it does.

[1] https://support.apple.com/en-us/HT204899
Commit:
