### PR TITLE
cmake: Correctly set RPATH accounting for OS X and CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,19 @@ SET_TARGET_PROPERTIES(${LOG4CPP_LIBRARY_NAME} PROPERTIES VERSION ${VERSION} SOVE
 # in dependent libraries/executables. Without this, CMake drops the path and
 # the dependency becomes just the lib name (which requires working DYLD_xxx)
 SET_TARGET_PROPERTIES(${LOG4CPP_LIBRARY_NAME} PROPERTIES
-    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+                      INSTALL_RPATH_USE_LINK_PATH ON)
+# Set INSTALL_NAME_DIR for MacOS X to tell users of this library how to find it:
+if(APPLE)
+    if (CMAKE_VERSION VERSION_LESS "3.0.0")
+        SET_TARGET_PROPERTIES( ${LOG4CPP_LIBRARY_NAME} PROPERTIES
+            INSTALL_NAME_DIR "@rpath"
+        )
+    else()
+        # cope with CMake 3.x
+        SET_TARGET_PROPERTIES( ${LOG4CPP_LIBRARY_NAME} PROPERTIES
+            MACOSX_RPATH ON)
+    endif()
+endif()
 
 ADD_DEFINITIONS(${LOG4CPP_CFLAGS})
 


### PR DESCRIPTION
Avoids the following error (OS X 10.11, SIP enabled, CMake 3.6)

-- Configuring done
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   log4cpp

This warning is for project developers.  Use -Wno-dev to suppress it.

-- Generating done

Tested on OS X 10.11/SIP enabled/CMake 3.6, and Mint 17.0/CMake 2.8.12.