### PR TITLE
Revert "Use O_LARGEFILE when creating log files on non-APPLE platforms."

### DIFF
--- a/src/FileAppender.cpp
+++ b/src/FileAppender.cpp
@@ -30,11 +30,7 @@ namespace log4cpp {
                                mode_t mode) : 
             LayoutAppender(name),
             _fileName(fileName),
-#ifdef __APPLE__
             _flags(O_CREAT | O_APPEND | O_WRONLY),
-#else
-            _flags(O_CREAT | O_APPEND | O_WRONLY | O_LARGEFILE),
-#endif
             _mode(mode) {
         if (!append)
             _flags |= O_TRUNC;
@@ -45,11 +41,7 @@ namespace log4cpp {
         LayoutAppender(name),
         _fileName(""),
         _fd(fd),
-#ifdef __APPLE__
         _flags(O_CREAT | O_APPEND | O_WRONLY),
-#else
-        _flags(O_CREAT | O_APPEND | O_WRONLY | O_LARGEFILE),
-#endif
         _mode(00644) {
     }
     


### PR DESCRIPTION
Fix for #8. This reverts commit eacabaf5f95cd11d671b351ccd474baa133acb1e.

Configuring large file system (LFS) support is a build system issue and should not be tackled by code changes. `O_LARGEFILE` is a GNU extension and is not supported on all platforms. If still required, the `-D_FILE_OFFSET_BITS=64` option should be added to the compiler command line via CMake.

See also section about `O_LARGEFILE` in http://man7.org/linux/man-pages/man2/open.2.html and http://man7.org/linux/man-pages/man7/feature_test_macros.7.html.