### PR TITLE
Run unit tests via cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,3 +166,9 @@ IF ( DOXYGEN_EXECUTABLE )
   CONFIGURE_FILE(doc/Doxyfile.in Doxyfile @ONLY)
   ADD_CUSTOM_TARGET(docs ${DOXYGEN_EXECUTABLE} "Doxyfile")
 ENDIF ( DOXYGEN_EXECUTABLE )
+
+###########################################################
+# TESTS
+###########################################################
+
+add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,48 @@
+include(CTest)
+
+# catkin compatibility
+if(NOT TARGET run_tests)
+  add_custom_target(run_tests)
+endif()
+
+if(BUILD_TESTING)
+  set(TESTS
+    testmain
+    testCategory testFixedContextCategory testNDC testPattern
+    testErrorCollision testPriority testFilter testProperties
+    testConfig testPropertyConfig testRollingFileAppender testDailyRollingFileAppender
+  )
+
+  set(DATA log4cpp.init log4cpp.properties testProperties.properties
+    testConfig.log4cpp.properties testConfig.log4cpp.dailyroll.properties
+  )
+
+  # copy test data
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  foreach(file ${DATA})
+    configure_file(${file} ${CMAKE_CURRENT_BINARY_DIR}/${file} COPYONLY)
+  endforeach()
+
+  include_directories(
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
+  )
+
+  foreach(test ${TESTS})
+    add_executable(${test} EXCLUDE_FROM_ALL ${test}.cpp)
+    target_link_libraries(${test} ${LOG4CPP_LIBRARY_NAME} -pthread)
+    add_test(NAME ${test} COMMAND ${test})
+  endforeach()
+
+  add_executable(testbench EXCLUDE_FROM_ALL Clock.cpp Clock.hh testbench.cpp)
+  target_link_libraries(testbench ${LOG4CPP_LIBRARY_NAME} -pthread)
+  add_test(NAME testbench COMMAND testbench)
+
+  add_custom_target(check
+    COMMAND ctest -V
+    DEPENDS ${TESTS} testbench
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+
+  add_dependencies(run_tests check)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,6 @@ endif()
 
 if(BUILD_TESTING)
   set(TESTS
-    testmain
     testCategory testFixedContextCategory testNDC testPattern
     testErrorCollision testPriority testFilter testProperties
     testConfig testPropertyConfig testRollingFileAppender testDailyRollingFileAppender
@@ -28,19 +27,23 @@ if(BUILD_TESTING)
     ${PROJECT_SOURCE_DIR}/src
   )
 
+  add_executable(testmain EXCLUDE_FROM_ALL testmain.cpp)
+  target_link_libraries(testmain ${LOG4CPP_LIBRARY_NAME} -pthread)
+  #add_test(NAME testmain COMMAND testmain)
+
+  add_executable(testbench EXCLUDE_FROM_ALL Clock.cpp Clock.hh testbench.cpp)
+  target_link_libraries(testbench ${LOG4CPP_LIBRARY_NAME} -pthread)
+  #add_test(NAME testbench COMMAND testbench)
+
   foreach(test ${TESTS})
     add_executable(${test} EXCLUDE_FROM_ALL ${test}.cpp)
     target_link_libraries(${test} ${LOG4CPP_LIBRARY_NAME} -pthread)
     add_test(NAME ${test} COMMAND ${test})
   endforeach()
 
-  add_executable(testbench EXCLUDE_FROM_ALL Clock.cpp Clock.hh testbench.cpp)
-  target_link_libraries(testbench ${LOG4CPP_LIBRARY_NAME} -pthread)
-  add_test(NAME testbench COMMAND testbench)
-
   add_custom_target(check
     COMMAND ctest -V
-    DEPENDS ${TESTS} testbench
+    DEPENDS ${TESTS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 


### PR DESCRIPTION
Upstream log4cpp contains some unit tests in the `tests` folder which can be compiled and run via cmake and ctest, like in RTT.

All unit tests pass successfully, with the exception of `testmain`, which on my system runs very long, which can be explained by looking at the code. It also seems to not run as part of the check target in the upstream [Makefile.am](https://github.com/orocos-toolchain/log4cpp/blob/upstream/tests/Makefile.am) and is probably meant for manual testing.

Tests do not run automatically, but only on request with `make check`. For compatibility with catkin target `run_tests` is also accepted.