### PR TITLE
Include stdarg.h unconditionally in StringUtil.cpp

### DIFF
--- a/src/StringUtil.cpp
+++ b/src/StringUtil.cpp
@@ -8,6 +8,7 @@
 #include "StringUtil.hh"
 #include <iterator>
 #include <stdio.h>
+#include <stdarg.h>
 
 #if defined(_MSC_VER)
     #define VSNPRINTF _vsnprintf
@@ -21,7 +22,6 @@
 #define PREFER_PORTABLE_SNPRINTF
 
 #include <stdlib.h>
-#include <stdarg.h>
 
 extern "C" {
 #include "snprintf.c"


### PR DESCRIPTION
This might fix a compile error ~~with GCC 5.5~~:

```
/home/travis/build/orocos-toolchain/orocos_toolchain/log4cpp/src/StringUtil.cpp: In static member function ‘static std::__cxx11::string log4cpp::StringUtil::vform(const char*, __va_list_tag*)’:
/home/travis/build/orocos-toolchain/orocos_toolchain/log4cpp/src/StringUtil.cpp:47:36: error: ‘va_copy’ was not declared in this scope
             va_copy(args_copy, args);
                                    ^
```

_Edit:_ This error also occurs with the default GCC version 5.4 in Ubuntu Xenial when building without C++11 support enabled.