### PR TITLE
package.xml/manifest.xml: update to package.xml format 3 and update maintainer email

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -4,7 +4,7 @@
     by adding custom category factories. Orocos requires this for
     setting up real-time logging.
   </description>
-  <license>LGPL-2.1</license>
+  <license>LGPL-2.1 or later</license>
   <url>http://log4cpp.sourceforge.net/</url>
 
   <author>Stephen Roderick, Bastiaan Bakker, Cedric Le Goater, Steve Ostlind, Marcel Harkema, Walter Stroebel, Glenn Scott and Tony Cheung</author>

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,18 +1,16 @@
 <package>
-    <description brief="Log4cpp maintained by Orocos developers">
-			This version of log4cpp deviates from the official release
-			by adding custom category factories. Orocos requires this for
-			setting up real-time logging.
-    </description>
-    <author>Stephen Roderick</author>
-    <copyright>Stephen Roderick, Bastiaan Bakker, Cedric Le Goater, Steve Ostlind, Marcel 
-		Harkema, Walter Stroebel, Glenn Scott and Tony Cheung.
-    </copyright>
-    <license>LGPL v2.1 or later</license>
-    <url>http://log4cpp.sourceforge.net/</url>
-		<export>
-			<cpp cflags="-I${prefix}/../install/include" lflags="-L${prefix}/../install/lib -Wl,-rpath,${prefix}/../install/lib"/>
-		</export>
+  <description brief="Log4cpp maintained by Orocos developers">
+    This version of log4cpp deviates from the official release
+    by adding custom category factories. Orocos requires this for
+    setting up real-time logging.
+  </description>
+  <license>LGPL-2.1</license>
+  <url>http://log4cpp.sourceforge.net/</url>
+
+  <author>Stephen Roderick, Bastiaan Bakker, Cedric Le Goater, Steve Ostlind, Marcel Harkema, Walter Stroebel, Glenn Scott and Tony Cheung</author>
+
+  <export>
+    <cpp cflags="-I${prefix}/../install/include" lflags="-L${prefix}/../install/lib -Wl,-rpath,${prefix}/../install/lib"/>
+  </export>
 
 </package>
-

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
     by adding custom category factories. Orocos requires this for
     setting up real-time logging.
   </description>
-  <license>LGPL-2.1</license>
+  <license>LGPL-2.1 or later</license>
   <maintainer email="orocos-dev@orocos.org">Orocos Developers</maintainer>
   <url>http://log4cpp.sourceforge.net/</url>
 

--- a/package.xml
+++ b/package.xml
@@ -1,25 +1,31 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>log4cpp</name>
   <version>2.9.1</version>
-  <description >
+  <description>
     Log4cpp maintained by Orocos developers
     This version of log4cpp deviates from the official release
     by adding custom category factories. Orocos requires this for
     setting up real-time logging.
   </description>
-  <author>Stephen Roderick, Bastiaan Bakker, Cedric Le Goater, Steve Ostlind, Marcel Harkema, Walter Stroebel, Glenn Scott and Tony Cheung</author>
-  <maintainer email="orocos-dev@lists.mech.kuleuven.be">Orocos Developers</maintainer>
-  <license>LGPL v2.1 or later</license>
+  <license>LGPL-2.1</license>
+  <maintainer email="orocos-dev@orocos.org">Orocos Developers</maintainer>
   <url>http://log4cpp.sourceforge.net/</url>
 
+  <author>Stephen Roderick</author>
+  <author>Bastiaan Bakker</author>
+  <author>Cedric Le Goater</author>
+  <author>Steve Ostlind</author>
+  <author>Marcel Harkema</author>
+  <author>Walter Stroebel</author>
+  <author>Glenn Scott</author>
+  <author>Tony Cheung</author>
+
   <buildtool_depend>cmake</buildtool_depend>
-  <run_depend>catkin</run_depend>
 
   <export>
-    <build_type>
-      cmake
-    </build_type>
+    <build_type>cmake</build_type>
   </export>
 
 </package>
-


### PR DESCRIPTION
Related PR in [rtt](https://github.com/orocos-toolchain/rtt): https://github.com/orocos-toolchain/rtt/pull/321
and [ocl](https://github.com/orocos-toolchain/ocl): https://github.com/orocos-toolchain/ocl/pull/90


> Format 3 is the latest specification of ROS package manifests ([REP-0149](https://www.ros.org/reps/rep-0149.html)).
> 
> Changes in `manifest.xml` are pure formatting.

... and the authors have been merged in tag `<author>`. `<copyright>` is not a valid tag according to [the ROS spec](https://docs.ros.org/independent/api/rospkg/html/manifest_xml.html).

The license tags in `manifest.xml` and `package.xml` have been wrong. log4cpp does not explicitly allow later versions of the LGPL v2.1 in its original [COPYING](https://github.com/orocos-toolchain/log4cpp/blob/13273469ab8059c137b40fc085dc62a92c6b802c/COPYING) file.